### PR TITLE
Enable local dataset training for chatterbox-j

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ python finetune_t3.py \
 --text_column_name text_scribe
 ```
 
+### Training from local folders
+
+```
+cd src
+python finetune_t3.py \
+  --output_dir ./checkpoints/local_run \
+  --model_name_or_path ResembleAI/chatterbox \
+  --data_root /abs/path/to/data \
+  --splits dub_ellen.ok dub_nele.rejected \
+  --eval_split_size 0.01 \
+  --num_train_epochs 1 \
+  --per_device_train_batch_size 4 \
+  --gradient_accumulation_steps 2 \
+  --learning_rate 5e-5 \
+  --warmup_steps 100 \
+  --logging_steps 10 \
+  --eval_strategy steps --eval_steps 2000 \
+  --save_strategy steps --save_steps 4000 --save_total_limit 4 \
+  --fp16 True --report_to tensorboard \
+  --dataloader_num_workers 8 --dataloader_pin_memory False \
+  --do_train --do_eval --eval_on_start True \
+  --label_names labels_speech --text_column_name text \
+  --target_sr 16000
+```
+
 
 
 

--- a/chatterbox/utils/training_args.py
+++ b/chatterbox/utils/training_args.py
@@ -14,4 +14,9 @@ class CustomTrainingArguments(HfTrainingArguments):
     dataloader_persistent_workers: bool = field(
         default=True, metadata={"help": "Use persistent workers for the dataloader."}
     )
+
+    dry_run_batches: Optional[int] = field(
+        default=None,
+        metadata={"help": "If set, iterate this many batches through the dataloader then exit."},
+    )
     


### PR DESCRIPTION
## Summary
- add `LocalChatterboxDataset` for discovering wav/txt pairs from a local folder
- add `--data_root`, `--splits`, `--target_sr`, and `--dry_run_batches` CLI options
- document training from local folders in README

## Testing
- `python -m py_compile chatterbox/data/local_folder_dataset.py chatterbox/utils/training_args.py src/finetune_t3.py finetune_t3_beam.py`


------
https://chatgpt.com/codex/tasks/task_e_6893643c92e4832fa7328c6ac8045b76